### PR TITLE
Update extract.js

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -172,4 +172,14 @@ Extract.prototype._write = function(data, enc, cb) {
 	this._onparse();
 };
 
+
+Extract.prototype.end = function(chunk, enc) {
+	if (chunk) this.write(chunk, enc);
+	if (this._stream) {
+		this._stream.on('end', this.emit.bind(this, 'end'));
+	} else {
+		this.emit('end');
+	}
+};
+
 module.exports = Extract;


### PR DESCRIPTION
Ensure that end is called on extraction

There is an issue I encountered when extracting archives. Everything is actually done, but contrary to the examples the 'end' even is never emitted. And actually I don't see how it ever would be with out this, since 'end' is not an even of a stream.Writable (used to be?)
