### PR TITLE
emit error on invalid header

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -75,7 +75,12 @@ var Extract = function(opts) {
 	};
 
 	var onheader = function() {
-		var header = self._header = headers.decode(b.slice(0, 512));
+		var header
+		try {
+			header = self._header = headers.decode(b.slice(0, 512));
+		} catch (err) {
+			self.emit('error', err)
+		}
 		b.consume(512);
 
 		if (!header) {


### PR DESCRIPTION
This emits an error when the checksum is incorrect (i.e. if you try to extract a .tgz without unzipping it first)

(I guessed the header is null where the checksum is the initial value, because there I didn't want to harm perf yet, and to make minimal changes)

I can add some test coverage if you want, this is a sort of PITA that wants a lot of coverage.
