### PR TITLE
adding missing readable stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,8 +8,9 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
+    "bl": "~0.6.0",
     "end-of-stream": "~0.1.3",
-    "bl": "~0.6.0"
+    "readable-stream": "~1.0.26-4"
   },
   "devDependencies": {
     "tap": "~0.4.6",


### PR DESCRIPTION
- although only used for node < 0.10, it still is [required in the code](https://github.com/mafintosh/tar-stream/blob/3da78340cb0cbe9ac06623bf4694b7bac7e59d28/extract.js#L6-L7)
- for node 0.8 it just breaks when trying to find that module

Actually @rvagg will tell you to **always** use readable stream to get the same stream interface regardless of your node version.
I can send another PR with that change if you so desire.

However this PR is most important since dependencies that are required (even if only in certain circumstances) need to be included. The saved disk space is not worth the headaches when running modules in different environments and see them breaking.
