### PR TITLE
update bl dependency to ~0.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "bl": "~0.6.0",
+    "bl": "~0.8.1",
     "end-of-stream": "~0.1.3",
     "readable-stream": "~1.0.26-4",
     "xtend": "~3.0.0"


### PR DESCRIPTION
I know this seems like a trivial pull request but I'm working on packaging up [Groove Basin](https://github.com/andrewrk/groovebasin/) for Debian, which indirectly depends on the `bl` module twice, with conflicting versions. NPM handles these version conflicts by simultaneously depending on multiple versions, while Debian requires that there be only one version of everything for security reasons. Fortunately, the solution is simple - if `tar-stream` updates to the latest version of `bl` then everybody is happy.

I have verified that the tests still pass. I would be grateful if you merged this and published a new version.
