### PR TITLE
more info in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,10 @@
   "name": "tar-stream",
   "version": "0.4.3",
   "description": "tar-stream is a streaming tar parser and generator and nothing else. It is streams2 and operates purely using streams which means you can easily extract/parse tarballs without ever hitting the file system.",
-  "repository": "git://github.com:mafintosh/tar-stream.git",
+  "repository": {
+    "type": "git",
+    "url": "git://github.com:mafintosh/tar-stream.git"
+  },
   "author": "Mathias Buus <mathiasbuus@gmail.com>",
   "engines": {
     "node": ">= 0.8.0"
@@ -35,5 +38,14 @@
     "pack",
     "extract",
     "modify"
-  ]
+  ],
+  "bugs": {
+    "url": "https://github.com/mafintosh/tar-stream/issues"
+  },
+  "homepage": "https://github.com/mafintosh/tar-stream",
+  "main": "index.js",
+  "directories": {
+    "test": "test"
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
I ran `npm init` on tar-stream which added, among other things, the license to package.json.
