### PR TITLE
Add `files` to package.son

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,10 @@
   },
   "homepage": "https://github.com/mafintosh/tar-stream",
   "main": "index.js",
+  "files": [
+    "./*.js",
+    "LICENSE"
+  ],
   "directories": {
     "test": "test"
   },


### PR DESCRIPTION
Because the `test` directory includes a lot of files and it doesn't have to be included in the npm package.

https://www.npmjs.org/doc/files/package.json.html#files
