### PR TITLE
Updated readable-stream and tape

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,12 @@
   "dependencies": {
     "bl": "^0.9.0",
     "end-of-stream": "^1.0.0",
-    "readable-stream": "^1.0.27-1",
+    "readable-stream": "^1.0.33",
     "xtend": "^4.0.0"
   },
   "devDependencies": {
     "concat-stream": "^1.4.6",
-    "tape": "^2.14.0"
+    "tape": "^3.0.3"
   },
   "scripts": {
     "test": "tape test/*.js"


### PR DESCRIPTION
Updated tape to 3.0.3 and readable-stream to 1.0.33.

Fixes https://github.com/mafintosh/tar-stream/issues/32