### PR TITLE
Only allow patch updates to readable-stream dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "bl": "^0.9.0",
     "end-of-stream": "^1.0.0",
-    "readable-stream": "^1.0.33",
+    "readable-stream": "~1.0.33",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
This ensures that readable-stream is always the Streams2 implementation.

Fixes mafintosh/tar-stream#36