### PR TITLE
make sure to emit error when entry handling is done

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -65,7 +65,10 @@ var Extract = function(opts) {
 
   var onunlock = function(err) {
     self._locked = false
-    if (err) return self.destroy(err)
+    if (err) {
+      self.emit('error', err)
+      return self.destroy()
+    }
     if (!self._stream) oncontinue()
   }
 


### PR DESCRIPTION
If the extractor gets destroyed during entry processing and an error is then given to onunlock then the error is not emitted at all. 

In my case this happened when using tar-fs and the 'pump' method encountered an error extracting an entry. The extractor got destroyed through the pump destroyer method without being given the error, and when tar-fs unlocked the entry the extractor was already destroyed, so the error was never emitted.

To reproduce, create a tar that contains a file with read only permission, and try to extract it twice to the same place. There should be a "EACCES" error emitted when trying to override the read only file during the second extraction.