### PR TITLE
bump bl to v1.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "node": ">= 0.8.0"
   },
   "dependencies": {
-    "bl": "^0.9.0",
+    "bl": "^1.0.0",
     "end-of-stream": "^1.0.0",
     "readable-stream": "^2.0.0",
     "xtend": "^4.0.0"


### PR DESCRIPTION
[bl](https://github.com/rvagg/bl) v1.x uses [readable-stream](https://github.com/nodejs/readable-stream) v2.x. https://github.com/rvagg/bl/pull/19
