### PR TITLE
Don't use octal numbers

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -166,7 +166,7 @@ exports.encode = function(opts) {
   if (opts.linkname && Buffer.byteLength(opts.linkname) > 100) return null
 
   buf.write(name)
-  buf.write(encodeOct(opts.mode & 07777, 6), 100)
+  buf.write(encodeOct(opts.mode & parseInt('07777', 8), 6), 100)
   buf.write(encodeOct(opts.uid, 6), 108)
   buf.write(encodeOct(opts.gid, 6), 116)
   buf.write(encodeOct(opts.size, 11), 124)

--- a/pack.js
+++ b/pack.js
@@ -118,7 +118,7 @@ Pack.prototype.entry = function(header, buffer, callback) {
 
   if (!header.size)  header.size = 0
   if (!header.type)  header.type = modeToType(header.mode)
-  if (!header.mode)  header.mode = header.type === 'directory' ? 0755 : 0644
+  if (!header.mode)  header.mode = parseInt(header.type === 'directory' ? '0755' : '0644')
   if (!header.uid)   header.uid = 0
   if (!header.gid)   header.gid = 0
   if (!header.mtime) header.mtime = new Date()


### PR DESCRIPTION
When run with the "--use_strict" flag, NodeJS raises an error citing:

    SyntaxError: Octal literals are not allowed in strict mode.

when parsing files which contain Octal numbers (or numbers which look
like octals - usually because they have leading zeros). This commit
replaces two instances of this with strings.

See [this Stack Overflow answer](http://stackoverflow.com/a/23609255/574190) for more info.