### PR TITLE
Ensure packed symlinks have size zero as required by GNU `tar`

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -117,7 +117,7 @@ Pack.prototype.entry = function (header, buffer, callback) {
 
   var self = this
 
-  if (!header.size) header.size = 0
+  if (!header.size || header.type === 'symlink') header.size = 0
   if (!header.type) header.type = modeToType(header.mode)
   if (!header.mode) header.mode = header.type === 'directory' ? DMODE : FMODE
   if (!header.uid) header.uid = 0

--- a/test/pack.js
+++ b/test/pack.js
@@ -110,7 +110,8 @@ test('types', function (t) {
     uname: 'maf',
     gname: 'staff',
     uid: 501,
-    gid: 20
+    gid: 20,
+    size: 9  // Should convert to zero
   })
 
   pack.finalize()


### PR DESCRIPTION
This should fix issues #44 and #48.