### PR TITLE
Increase required readable-stream version to v2.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "buffer-alloc": "^1.1.0",
     "end-of-stream": "^1.0.0",
     "fs-constants": "^1.0.0",
-    "readable-stream": "^2.0.0",
+    "readable-stream": "^2.3.0",
     "to-buffer": "^1.1.0",
     "xtend": "^4.0.0"
   },


### PR DESCRIPTION
[readable-stream v2.3.0][1] is the version that introduced support for `_final`, which is [used in extract.js][2] to detect incomplete input.

 [1]: https://github.com/nodejs/readable-stream/releases/tag/v2.3.0
 [2]: https://github.com/mafintosh/tar-stream/blob/59abdc85c0eb1406c845d4bdba973ebf95c009ca/extract.js#L253