### PR TITLE
Add support for gnu extension size field

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -11,7 +11,7 @@ var MASK = parseInt('7777', 8)
 var DIVIDEND_HIGH_32BIT = Math.pow(2, 32)
 
 var getUnisgnedHigh32 = function (val) {
-  return (val / DIVIDEND_HIGH_32BIT) >> 0
+  return (val / DIVIDEND_HIGH_32BIT) >>> 0
 }
 
 var getUnsignedLow32 = function (val) {

--- a/headers.js
+++ b/headers.js
@@ -10,6 +10,12 @@ var MASK = parseInt('7777', 8)
 // Divide this number to get high 32 bit (JS unsafe)
 var DIVIDEND_HIGH_32BIT = Math.pow(2, 32)
 
+// Number.isSafeInteger polyfill
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
+var isSafeInteger = Number.isSafeInteger || function (value) {
+  return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER
+}
+
 var getUnisgnedHigh32 = function (val) {
   return (val / DIVIDEND_HIGH_32BIT) >>> 0
 }
@@ -126,7 +132,7 @@ var writeEncodedSize = function (buf, offset, size, allowGnuExtension) {
   // Then try gnu extension if enabled and can fit (uint32_be(0x80000000) + int64_be(size))
   // Otherwise, use the old encodeOct routine.
   // See 7-zip source, 7z1805-src.7z/CPP/7zip/Archive/Tar/TarIn.cpp#ParseSize
-  if (size > MAX_OCT_SIZE && Number.isSafeInteger(size) && allowGnuExtension) {
+  if (size > MAX_OCT_SIZE && isSafeInteger(size) && allowGnuExtension) {
     // writeUIntBE == writeUInt32BE in node < v10.0.0
     // 0x80000000 GNU Extension Flag
     buf.writeUInt32BE(0x80000000, offset)

--- a/headers.js
+++ b/headers.js
@@ -28,9 +28,9 @@ var MAX_OCT_SIZE = parseInt('77777777777', 8)
 
 // This function is unsafe, as JavaScript can only represent 53 bit.
 var makeSigned64 = function (high, low) {
-    if (high > MAX_SAFE_HIGH_INT32 || (high === MAX_SAFE_HIGH_INT32 && low > MAX_SAFE_LOW_UINT32)) {
-      throw new Error('unsafe gnu extension size')
-    }
+  if (high > MAX_SAFE_HIGH_INT32 || (high === MAX_SAFE_HIGH_INT32 && low > MAX_SAFE_LOW_UINT32)) {
+    throw new Error('unsafe gnu extension size')
+  }
   return (high * DIVIDEND_HIGH_32BIT) + low
 }
 

--- a/headers.js
+++ b/headers.js
@@ -10,7 +10,7 @@ var MASK = parseInt('7777', 8)
 // Divide this number to get high 32 bit (JS unsafe)
 var DIVIDEND_HIGH_32BIT = Math.pow(2, 32)
 
-var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || (Math.pow(2, 53) - 1);
+var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || (Math.pow(2, 53) - 1)
 
 // isInteger polyfill
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger

--- a/headers.js
+++ b/headers.js
@@ -10,16 +10,18 @@ var MASK = parseInt('7777', 8)
 // Divide this number to get high 32 bit (JS unsafe)
 var DIVIDEND_HIGH_32BIT = Math.pow(2, 32)
 
-// Number.isInteger polyfill
+var MAX_SAFE_INTEGER = Number.MAX_SAFE_INTEGER || (Math.pow(2, 53) - 1);
+
+// isInteger polyfill
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
 var isInteger = Number.isInteger || function (value) {
   return typeof value === 'number' && isFinite(value) && Math.floor(value) === value
 }
 
-// Number.isSafeInteger polyfill
+// isSafeInteger polyfill
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
 var isSafeInteger = Number.isSafeInteger || function (value) {
-  return isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER
+  return isInteger(value) && Math.abs(value) <= MAX_SAFE_INTEGER
 }
 
 var getUnisgnedHigh32 = function (val) {
@@ -32,8 +34,8 @@ var getUnsignedLow32 = function (val) {
 
 // If there's 64 bit:
 // MAX_SAFE_INT64 = (MAX_SAFE_HIGH_INT32 << 32) | MAX_SAFE_LOW_UINT32
-var MAX_SAFE_HIGH_INT32 = getUnisgnedHigh32(Number.MAX_SAFE_INTEGER)
-var MAX_SAFE_LOW_UINT32 = getUnsignedLow32(Number.MAX_SAFE_INTEGER)
+var MAX_SAFE_HIGH_INT32 = getUnisgnedHigh32(MAX_SAFE_INTEGER)
+var MAX_SAFE_LOW_UINT32 = getUnsignedLow32(MAX_SAFE_INTEGER)
 
 // Max individual file size
 var MAX_OCT_SIZE = parseInt('77777777777', 8)

--- a/headers.js
+++ b/headers.js
@@ -10,10 +10,16 @@ var MASK = parseInt('7777', 8)
 // Divide this number to get high 32 bit (JS unsafe)
 var DIVIDEND_HIGH_32BIT = Math.pow(2, 32)
 
+// Number.isInteger polyfill
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger
+var isInteger = Number.isInteger || function (value) {
+  return typeof value === 'number' && isFinite(value) && Math.floor(value) === value
+}
+
 // Number.isSafeInteger polyfill
 // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isSafeInteger
 var isSafeInteger = Number.isSafeInteger || function (value) {
-  return Number.isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER
+  return isInteger(value) && Math.abs(value) <= Number.MAX_SAFE_INTEGER
 }
 
 var getUnisgnedHigh32 = function (val) {

--- a/headers.js
+++ b/headers.js
@@ -24,7 +24,7 @@ var isSafeInteger = Number.isSafeInteger || function (value) {
   return isInteger(value) && Math.abs(value) <= MAX_SAFE_INTEGER
 }
 
-var getUnisgnedHigh32 = function (val) {
+var getUnsignedHigh32 = function (val) {
   return (val / DIVIDEND_HIGH_32BIT) >>> 0
 }
 
@@ -34,7 +34,7 @@ var getUnsignedLow32 = function (val) {
 
 // If there's 64 bit:
 // MAX_SAFE_INT64 = (MAX_SAFE_HIGH_INT32 << 32) | MAX_SAFE_LOW_UINT32
-var MAX_SAFE_HIGH_INT32 = getUnisgnedHigh32(MAX_SAFE_INTEGER)
+var MAX_SAFE_HIGH_INT32 = getUnsignedHigh32(MAX_SAFE_INTEGER)
 var MAX_SAFE_LOW_UINT32 = getUnsignedLow32(MAX_SAFE_INTEGER)
 
 // Max individual file size
@@ -147,7 +147,7 @@ var writeEncodedSize = function (buf, offset, size, allowGnuExtension) {
 
     // high.i32 is signed; low.i32 is unsigned
     // if high.i32 is negative, writeInt32BE will throw an error refuse it.
-    buf.writeInt32BE(getUnisgnedHigh32(size), offset + 4)
+    buf.writeInt32BE(getUnsignedHigh32(size), offset + 4)
     buf.writeUInt32BE(getUnsignedLow32(size), offset + 8)
   } else {
     buf.write(encodeOct(size, 11), offset)

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "tape": "^4.9.0"
   },
   "scripts": {
-    "test": "standard && tape test/extract.js test/pack.js",
+    "test": "standard && tape test/extract.js test/pack.js test/gnu-size-header.js",
     "test-all": "standard && tape test/*.js"
   },
   "keywords": [

--- a/test/gnu-size-header.js
+++ b/test/gnu-size-header.js
@@ -1,0 +1,135 @@
+var test = require('tape')
+var headers = require('../headers')
+
+var mtime = new Date(0)
+
+test('it should not use gnu extension for size when is safe to encode in oct', function (t) {
+  t.plan(3)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: parseInt('12345671234', 8),
+    allowGnuExtension: true
+  })
+
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x31323334, '[ :4] should be 1234')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x35363731, '[4:8] should be 5671')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x32333420, '[8: ] should be 234 ')
+})
+
+test('it should not try to use gnu extension when allowGnuExtension is not specified', function (t) {
+  t.plan(3)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0x1FED01020304
+  })
+
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x37373737, '[ :4] should be 7777')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x37373737, '[4:8] should be 7777')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x37373720, '[8: ] should be 777 ')
+})
+
+test('it should use gnu extension when allowGnuExtension is set to true for size 0x1FED01020304', function (t) {
+  t.plan(3)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0x1FED01020304,
+    allowGnuExtension: true
+  })
+
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x80000000, 'gnu extension flag set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x00001FED, 'high 32 bit set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x01020304, 'low  32 bit set correctly')
+})
+
+test('it should fall back to "77777777777 " when allowGnuExtension is false', function (t) {
+  t.plan(3)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0x1FED01020304,
+    allowGnuExtension: false
+  })
+
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x37373737, '[ :4] should be 7777')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x37373737, '[4:8] should be 7777')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x37373720, '[8: ] should be 777 ')
+})
+
+test('it should decode gnu extension size correctly (low.i32 is positive)', function (t) {
+  t.plan(4)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0x1FED01020304,
+    allowGnuExtension: true
+  })
+
+  // Ensure we have the correct binary data first
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x80000000, 'gnu extension flag set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x00001FED, 'high 32 bit set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x01020304, 'low  32 bit set correctly')
+
+  var decode = headers.decode(header)
+  t.strictEqual(decode.size, 0x1FED01020304, 'size should equal 0x1FED01020304')
+})
+
+test('it should decode gnu extension size correctly (low.i32 is negative)', function (t) {
+  t.plan(4)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0x1FED81020304,
+    allowGnuExtension: true
+  })
+
+  // Ensure we have the correct binary data first
+  t.strictEqual(header.readUInt32BE(124 + 0), 0x80000000, 'gnu extension flag set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 4), 0x00001FED, 'high 32 bit set correctly')
+  t.strictEqual(header.readUInt32BE(124 + 8), 0x81020304, 'low  32 bit set correctly')
+
+  var decode = headers.decode(header)
+  t.strictEqual(decode.size, 0x1FED81020304, 'size should equal 0x1FED81020304')
+})
+
+test('it should throw error if gnu extension size is too high (> Number.MAX_SAFE_INTEGER)', function (t) {
+  t.plan(1)
+
+  var header = headers.encode({
+    uid: 0,
+    gid: 0,
+    mtime: mtime,
+    name: 'do not care',
+    size: 0,
+    allowGnuExtension: true
+  })
+
+  // Set an unsafe value
+  header.writeUInt32BE(0x80000000, 124 + 0)
+  header.writeUInt32BE(0x7FFFFFFF, 124 + 4)
+  header.writeUInt32BE(0xFFFFFFFF, 124 + 8)
+
+  t.throws(function () {
+    headers.decode(header)
+  }, new Error('unsafe gnu extension size'), 'should throw error for unsafe gnu extension size')
+})


### PR DESCRIPTION
Not all compression gui can handle PaxHeader correctly (e.g. 7-zip in some cases)

![image](https://user-images.githubusercontent.com/5713045/45190811-bf771d00-b237-11e8-8db3-2ae23eb19967.png)

By using gnu extension size field we can safely add file up to ~9PE~ 8PB (depends on the value of `Number.MAX_SAFE_INTEGER`)