### PR TITLE
Bump buffer-alloc to 1.2.0 and to-buffer to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,11 +8,11 @@
   },
   "dependencies": {
     "bl": "^1.0.0",
-    "buffer-alloc": "^1.1.0",
+    "buffer-alloc": "^1.2.0",
     "end-of-stream": "^1.0.0",
     "fs-constants": "^1.0.0",
     "readable-stream": "^2.3.0",
-    "to-buffer": "^1.1.0",
+    "to-buffer": "^1.1.1",
     "xtend": "^4.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I've been seeing warnings for a while when using the Yarn package manager about the `Buffer` constructor API [being deprecated](https://github.com/nodejs/node/issues/9531) in favor of `Buffer.from` and `Buffer.alloc`.

Yarn depends on tar-stream, and two of tar-stream's dependencies use `new Buffer`, but happily newer versions of both those dependencies exist that check if the appropriate new API is available and use that instead.
- buffer-alloc 1.2.0 bumps its dependency on buffer-fill to 1.0.0, which includes a new [check for `Buffer.alloc`](https://github.com/LinusU/buffer-fill/commit/01faf1761a0899dcfd6bc66239452d8d69c5f7b7)
- to-buffer 1.1.1 [checks for `Buffer.from`](https://github.com/mafintosh/to-buffer/commit/eebe20e0603e2c6a542b00316f1661741fdf1124) and uses it if it's available. Also I just realized to-buffer is also your project so you knew that already 🙂 

I ran the tar-stream tests on my machine, and they passed. After that I used `yarn link` to pull my modified version of tar-stream into my local copy of Yarn, and found that this fixed the deprecation warnings. So once you merge this PR and release a new version of tar-stream, I'll make a PR to Yarn to bump the tar-stream version there, and that should make the message go away for Yarn users.

Cheers!
-Jake