### PR TITLE
Removed logically dead code from parse256

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -112,16 +112,11 @@ function parse256 (buf) {
   else return null
 
   // build up a base-256 tuple from the least sig to the highest
-  var zero = false
   var tuple = []
   for (var i = buf.length - 1; i > 0; i--) {
     var byte = buf[i]
     if (positive) tuple.push(byte)
-    else if (zero && byte === 0) tuple.push(0)
-    else if (zero) {
-      zero = false
-      tuple.push(0x100 - byte)
-    } else tuple.push(0xFF - byte)
+    else tuple.push(0xFF - byte)
   }
 
   var sum = 0


### PR DESCRIPTION
zero is always set to false -- why does the code have two conditionals that depend on it being true?

This dead code was in the original parse256 from node-tar as well... Perhaps it was being kept to keep the code as similar as possible?