### PR TITLE
Bump bl dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "tar-stream is a streaming tar parser and generator and nothing else. It is streams2 and operates purely using streams which means you can easily extract/parse tarballs without ever hitting the file system.",
   "author": "Mathias Buus <mathiasbuus@gmail.com>",
   "dependencies": {
-    "bl": "^3.0.0",
+    "bl": "^4.0.1",
     "end-of-stream": "^1.4.1",
     "fs-constants": "^1.0.0",
     "inherits": "^2.0.3",


### PR DESCRIPTION
- Bump bl dependency essentially for this PR https://github.com/rvagg/bl/pull/80
- The breaking change for 4.0 seems to be their dropping of Node.js 4 support (I don't see an `engines` defined in your `package.json`, so not sure what lowest Node.js you support.