### PR TITLE
pack backpressure

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -128,9 +128,10 @@ Pack.prototype.entry = function (header, buffer, callback) {
   if (Buffer.isBuffer(buffer)) {
     header.size = buffer.length
     this._encode(header)
-    this.push(buffer)
+    var ok = this.push(buffer)
     overflow(self, header.size)
-    process.nextTick(callback)
+    if (ok) process.nextTick(callback)
+    else this._drain = callback
     return new Void()
   }
 

--- a/test/pack.js
+++ b/test/pack.js
@@ -200,7 +200,7 @@ test('backpressure', function (t) {
 
   var pack = tar.pack()
   var later = false
-  
+
   setImmediate(() => {
     later = true
   })


### PR DESCRIPTION
Heya,

I'm using this amazing lib to `pack` GBs of geographic data and then pipe it on to `bzip2` for compression.
Unfortunately `bzip2` is sloooow, so those GBs I packed end up being buffered in nodejs memory waiting for `bzip2` to ask for more.

The source of my memory woes seems to be that the return variable from `this.push()` isn't being checked which results in `pack._readableState.buffer.length` growing uncontrolled until I run out of RAM 😭 

Looking at the source code there is already a `this._drain` variable which is perfect for implementing backpressure:

```diff
diff --git a/pack.js b/pack.js
index ba4eece..f1da3b7 100644
--- a/pack.js
+++ b/pack.js
@@ -128,9 +128,10 @@ Pack.prototype.entry = function (header, buffer, callback) {
   if (Buffer.isBuffer(buffer)) {
     header.size = buffer.length
     this._encode(header)
-    this.push(buffer)
+    var ok = this.push(buffer)
     overflow(self, header.size)
-    process.nextTick(callback)
+    if (ok) process.nextTick(callback)
+    else this._drain = callback
     return new Void()
   }
```

I've added a simple test case which I'm happy to clean up if this PR is acceptable?

The difference you'll notice in how the test displays are:
- without this PR all 24 items are queued in memory
- with this PR only the first 16 are initially queued and the remaining items are only added as requested.

Please let me know if you think this is something you would consider including 🙇 