### PR TITLE
Fix encodeOct to parse correctly headers and do not add extra space to support old tar formats

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -94,8 +94,8 @@ var cksum = function (block) {
 
 var encodeOct = function (val, n) {
   val = val.toString(8)
-  if (val.length > n) return SEVENS.slice(0, n) + ' '
-  else return ZEROS.slice(0, n - val.length) + val + ' '
+  if (val.length > n) return SEVENS.slice(0, n)
+  else return ZEROS.slice(0, n - val.length) + val
 }
 
 /* Copied from the node-tar repo and modified to meet
@@ -213,9 +213,9 @@ exports.encode = function (opts) {
   if (opts.linkname && Buffer.byteLength(opts.linkname) > 100) return null
 
   buf.write(name)
-  buf.write(encodeOct(opts.mode & MASK, 6), 100)
-  buf.write(encodeOct(opts.uid, 6), 108)
-  buf.write(encodeOct(opts.gid, 6), 116)
+  buf.write(encodeOct(opts.mode & MASK, 7), 100)
+  buf.write(encodeOct(opts.uid, 7), 108)
+  buf.write(encodeOct(opts.gid, 7), 116)
   buf.write(encodeOct(opts.size, 11), 124)
   buf.write(encodeOct((opts.mtime.getTime() / 1000) | 0, 11), 136)
 
@@ -227,12 +227,12 @@ exports.encode = function (opts) {
   USTAR_VER.copy(buf, VERSION_OFFSET)
   if (opts.uname) buf.write(opts.uname, 265)
   if (opts.gname) buf.write(opts.gname, 297)
-  buf.write(encodeOct(opts.devmajor || 0, 6), 329)
-  buf.write(encodeOct(opts.devminor || 0, 6), 337)
+  buf.write(encodeOct(opts.devmajor || 0, 7), 329)
+  buf.write(encodeOct(opts.devminor || 0, 7), 337)
 
   if (prefix) buf.write(prefix, 345)
 
-  buf.write(encodeOct(cksum(buf), 6), 148)
+  buf.write(encodeOct(cksum(buf), 7), 148)
 
   return buf
 }


### PR DESCRIPTION
I've faced the issue with wrongly parsed header of old tar format accepted by busybox. Based on the https://en.wikipedia.org/wiki/Tar_%28computing%29#File_format. For `uid` header, for example, it should be used all 7 bytes instead of parsing 6 and adding a space. The allocated buffer then uses \0 by default on the remaining bytes.

This seems to be fixed for `size` and `mtime` headers. Using 11 instead of ten.

Please take a look and try and let me know if I'm wrong but for me this works. Cheers.

Mastermind of the fix @sairon