### PR TITLE
pack.entry() fails if a buffer of sufficiently large size is passed in

### DIFF
--- a/test/pack.js
+++ b/test/pack.js
@@ -233,3 +233,11 @@ test('backpressure', function (t) {
 
   next()
 })
+
+test('bigentry', function (t) {
+  t.timeoutAfter(30 * 1000)
+  const pack = tar.pack()
+  const entry = pack.entry({ name: 'file' }, Buffer.alloc(65400), () => {
+    t.end()
+  })
+})


### PR DESCRIPTION
Sending this PR of a failing test to demonstrate that adding an entry of sufficient size fails.

This test passes in the previous version but breaks after https://github.com/mafintosh/tar-stream/pull/114 .

Is there something different that needs to be done when the backpressure mechanism is activated and the callback is set to the `._drain` var? If so, that's not discussed in the documentation from what I can tell.