### PR TITLE
Document minimum supported Node.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,5 +51,8 @@
   "repository": {
     "type": "git",
     "url": "git+https://github.com/mafintosh/tar-stream.git"
+  },
+  "engines": {
+    "node": ">=6"
   }
 }


### PR DESCRIPTION
I inferred this from the usage of `Buffer.alloc` and the Travis file ☺️ 