### PR TITLE
Use object shorthand for properties

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -277,17 +277,17 @@ exports.decode = function (buf, filenameEncoding) {
   if (typeflag === 0 && name && name[name.length - 1] === '/') typeflag = 5
 
   return {
-    name: name,
-    mode: mode,
-    uid: uid,
-    gid: gid,
-    size: size,
+    name,
+    mode,
+    uid,
+    gid,
+    size,
     mtime: new Date(1000 * mtime),
-    type: type,
-    linkname: linkname,
-    uname: uname,
-    gname: gname,
-    devmajor: devmajor,
-    devminor: devminor
+    type,
+    linkname,
+    uname,
+    gname,
+    devmajor,
+    devminor
   }
 }


### PR DESCRIPTION
This rule is on its way into the latest Standard ☺️ 

ref: https://github.com/standard/eslint-config-standard/pull/166

Compatibility: This syntax is available from Node.js 4.x and up, and this module already uses `Buffer.alloc` introduced in Node.js 5.10 ✅ 