### PR TITLE
Update bl dep to pull in new buffer and reduce browser bloat

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "tar-stream is a streaming tar parser and generator and nothing else. It is streams2 and operates purely using streams which means you can easily extract/parse tarballs without ever hitting the file system.",
   "author": "Mathias Buus <mathiasbuus@gmail.com>",
   "dependencies": {
-    "bl": "^4.0.3",
+    "bl": "^5.0.0",
     "end-of-stream": "^1.4.1",
     "fs-constants": "^1.0.0",
     "inherits": "^2.0.3",


### PR DESCRIPTION
To reduce the number of duplicate copies of `buffer` in the dep tree for browser bundles, use the latest `bl` to get the latest `buffer`.

BREAKING CHANGE: `bl@5.x.x` uses `buffer@6.x.x` which drops support for IE and Safari < 10