### PR TITLE
Remove `fs` dependency to simplify web bundling

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,12 +1,8 @@
-try {
-  module.exports = require('fs').constants
-} catch {
-  module.exports = { // just for envs without fs
-    S_IFMT: 61440,
-    S_IFDIR: 16384,
-    S_IFCHR: 8192,
-    S_IFBLK: 24576,
-    S_IFIFO: 4096,
-    S_IFLNK: 40960
-  }
+module.exports = {
+  S_IFMT: 61440,
+  S_IFDIR: 16384,
+  S_IFCHR: 8192,
+  S_IFBLK: 24576,
+  S_IFIFO: 4096,
+  S_IFLNK: 40960
 }


### PR DESCRIPTION
This change removes `fs` dependency which greatly simplifies bundling of this package for web. Should have no effect on Node.js users.