### PR TITLE
Handle `fs` empty object

### DIFF
--- a/constants.js
+++ b/constants.js
@@ -1,12 +1,14 @@
+const constants = { // just for envs without fs
+  S_IFMT: 61440,
+  S_IFDIR: 16384,
+  S_IFCHR: 8192,
+  S_IFBLK: 24576,
+  S_IFIFO: 4096,
+  S_IFLNK: 40960
+}
+
 try {
-  module.exports = require('fs').constants
+  module.exports = require('fs').constants || constants
 } catch {
-  module.exports = { // just for envs without fs
-    S_IFMT: 61440,
-    S_IFDIR: 16384,
-    S_IFCHR: 8192,
-    S_IFBLK: 24576,
-    S_IFIFO: 4096,
-    S_IFLNK: 40960
-  }
+  module.exports = constants
 }


### PR DESCRIPTION
In browser environment with current package.json `fs` is empty object, which results in `constants` being undefined.

More details [here](https://github.com/mafintosh/tar-stream/pull/151#issuecomment-1596249740).

With current `package.json` config:

```js
browser: {
  fs: false
}
```

The way `require('fs')` resolves in Webpack 5 is with an empty object. Which leads to `constants` being `undefined`. This should hopefully fix it.