### PR TITLE
Allow passing empty bodies for "void" headers

### DIFF
--- a/pack.js
+++ b/pack.js
@@ -73,7 +73,10 @@ class Sink extends Writable {
     }
 
     if (this._isVoid) {
-      return cb(new Error('No body allowed for this entry'))
+      if (data.byteLength > 0) {
+        return cb(new Error('No body allowed for this entry'))
+      }
+      return cb()
     }
 
     this.written += data.byteLength

--- a/test/pack.js
+++ b/test/pack.js
@@ -124,6 +124,30 @@ test('types', function (t) {
   }))
 })
 
+test('empty directory body is valid', function (t) {
+  t.plan(1)
+
+  const pack = tar.pack()
+
+  pack.entry({
+    name: 'directory',
+    mtime: new Date(1387580181000),
+    type: 'directory',
+    mode: 0o755,
+    uname: 'maf',
+    gname: 'staff',
+    uid: 501,
+    gid: 20
+  }, '')
+
+  pack.finalize()
+
+  pack.resume()
+
+  pack.on('error', () => t.fail('should not throw'))
+  pack.on('close', () => t.pass('closed'))
+})
+
 test('long-name', function (t) {
   t.plan(2)
 


### PR DESCRIPTION
This restores the behavior of 2.x and 3.0.0