### PR TITLE
Reduce `b4a` usage and prefer the native `Buffer` methods

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -1,9 +1,8 @@
 const { Writable, Readable, getStreamError } = require('streamx')
 const FIFO = require('fast-fifo')
-const b4a = require('b4a')
 const headers = require('./headers')
 
-const EMPTY = b4a.alloc(0)
+const EMPTY = Buffer.alloc(0)
 
 class BufferList {
   constructor () {
@@ -38,7 +37,7 @@ class BufferList {
       chunks.push(chunk)
     }
 
-    return b4a.concat(chunks)
+    return Buffer.concat(chunks)
   }
 
   _next (size) {

--- a/headers.js
+++ b/headers.js
@@ -3,10 +3,10 @@ const b4a = require('b4a')
 const ZEROS = '0000000000000000000'
 const SEVENS = '7777777777777777777'
 const ZERO_OFFSET = '0'.charCodeAt(0)
-const USTAR_MAGIC = b4a.from([0x75, 0x73, 0x74, 0x61, 0x72, 0x00]) // ustar\x00
-const USTAR_VER = b4a.from([ZERO_OFFSET, ZERO_OFFSET])
-const GNU_MAGIC = b4a.from([0x75, 0x73, 0x74, 0x61, 0x72, 0x20]) // ustar\x20
-const GNU_VER = b4a.from([0x20, 0x00])
+const USTAR_MAGIC = Buffer.from([0x75, 0x73, 0x74, 0x61, 0x72, 0x00]) // ustar\x00
+const USTAR_VER = Buffer.from([ZERO_OFFSET, ZERO_OFFSET])
+const GNU_MAGIC = Buffer.from([0x75, 0x73, 0x74, 0x61, 0x72, 0x20]) // ustar\x20
+const GNU_VER = Buffer.from([0x20, 0x00])
 const MASK = 0o7777
 const MAGIC_OFFSET = 257
 const VERSION_OFFSET = 263
@@ -25,7 +25,7 @@ exports.encodePax = function encodePax (opts) { // TODO: encode more stuff in pa
       result += addLength(' ' + key + '=' + pax[key] + '\n')
     }
   }
-  return b4a.from(result)
+  return Buffer.from(result)
 }
 
 exports.decodePax = function decodePax (buf) {
@@ -49,22 +49,22 @@ exports.decodePax = function decodePax (buf) {
 }
 
 exports.encode = function encode (opts) {
-  const buf = b4a.alloc(512)
+  const buf = Buffer.alloc(512)
   let name = opts.name
   let prefix = ''
 
   if (opts.typeflag === 5 && name[name.length - 1] !== '/') name += '/'
-  if (b4a.byteLength(name) !== name.length) return null // utf-8
+  if (Buffer.byteLength(name) !== name.length) return null // utf-8
 
-  while (b4a.byteLength(name) > 100) {
+  while (Buffer.byteLength(name) > 100) {
     const i = name.indexOf('/')
     if (i === -1) return null
     prefix += prefix ? '/' + name.slice(0, i) : name.slice(0, i)
     name = name.slice(i + 1)
   }
 
-  if (b4a.byteLength(name) > 100 || b4a.byteLength(prefix) > 155) return null
-  if (opts.linkname && b4a.byteLength(opts.linkname) > 100) return null
+  if (Buffer.byteLength(name) > 100 || Buffer.byteLength(prefix) > 155) return null
+  if (opts.linkname && Buffer.byteLength(opts.linkname) > 100) return null
 
   b4a.write(buf, name)
   b4a.write(buf, encodeOct(opts.mode & MASK, 6), 100)
@@ -313,7 +313,7 @@ function decodeStr (val, offset, length, encoding) {
 }
 
 function addLength (str) {
-  const len = b4a.byteLength(str)
+  const len = Buffer.byteLength(str)
   let digits = Math.floor(Math.log(len) / Math.log(10)) + 1
   if (len + digits >= Math.pow(10, digits)) digits++
 

--- a/pack.js
+++ b/pack.js
@@ -7,7 +7,7 @@ const headers = require('./headers')
 const DMODE = 0o755
 const FMODE = 0o644
 
-const END_OF_TAR = b4a.alloc(1024)
+const END_OF_TAR = Buffer.alloc(1024)
 
 class Sink extends Writable {
   constructor (pack, header, callback) {
@@ -68,7 +68,7 @@ class Sink extends Writable {
 
   _write (data, cb) {
     if (this._isLinkname) {
-      this._linkname = this._linkname ? b4a.concat([this._linkname, data]) : data
+      this._linkname = this._linkname ? Buffer.concat([this._linkname, data]) : data
       return cb(null)
     }
 
@@ -151,7 +151,7 @@ class Pack extends Readable {
     if (!header.gid) header.gid = 0
     if (!header.mtime) header.mtime = new Date()
 
-    if (typeof buffer === 'string') buffer = b4a.from(buffer)
+    if (typeof buffer === 'string') buffer = Buffer.from(buffer)
 
     const sink = new Sink(this, header, callback)
 
@@ -283,5 +283,5 @@ function overflow (self, size) {
 }
 
 function mapWritable (buf) {
-  return b4a.isBuffer(buf) ? buf : b4a.from(buf)
+  return b4a.isBuffer(buf) ? buf : Buffer.from(buf)
 }

--- a/test/pack.js
+++ b/test/pack.js
@@ -1,7 +1,6 @@
 const test = require('brittle')
 const concat = require('concat-stream')
 const fs = require('fs')
-const b4a = require('b4a')
 const { Writable } = require('streamx')
 const tar = require('..')
 const fixtures = require('./fixtures')
@@ -256,7 +255,7 @@ test('backpressure', async function (t) {
         gid: 20
       }
 
-      const buffer = b4a.alloc(1024)
+      const buffer = Buffer.alloc(1024)
 
       pack.entry(header, buffer, next)
     } else {


### PR DESCRIPTION
The PR reduces some `b4a` usages:

- `b4a.alloc`
  - `b4a.alloc` is just an alias of `Buffer.alloc`, see https://github.com/holepunchto/b4a/blob/5a6b328df1817977351208e1991b1fdfb4bfa529/index.js#L9-#L11
- `b4a.concat`
  - `b4a.concat` is just an alias of `Buffer.concat`, see https://github.com/holepunchto/b4a/blob/5a6b328df1817977351208e1991b1fdfb4bfa529/index.js#L29-L31
- `b4a.from`
  - `b4a.from` is just an alias of `Buffer.from`, see https://github.com/holepunchto/b4a/blob/5a6b328df1817977351208e1991b1fdfb4bfa529/index.js#L45-L47
- `b4a.byteLength`
  - `b4a.byteLength` is just an alias of `Buffer.byteLength`, see https://github.com/holepunchto/b4a/blob/5a6b328df1817977351208e1991b1fdfb4bfa529/index.js#L21

By replacing those `b4a` usage with Node.js built-in `Buffer`, the PR improves performance (as those alias methods would create extra stacks), and makes it easier to transition to the Uint8Array in future PRs.

The unit tests still pass after the changes.