### PR TITLE
Fix header decoding sometimes failing in the browser

### DIFF
--- a/headers.js
+++ b/headers.js
@@ -34,7 +34,7 @@ exports.decodePax = function decodePax (buf) {
   while (buf.length) {
     let i = 0
     while (i < buf.length && buf[i] !== 32) i++
-    const len = parseInt(buf.subarray(0, i).toString(), 10)
+    const len = parseInt(b4a.toString(buf.subarray(0, i)), 10)
     if (!len) return result
 
     const b = b4a.toString(buf.subarray(i + 1, len - 1))
@@ -304,7 +304,7 @@ function decodeOct (val, offset, length) {
     const end = clamp(indexOf(val, 32, offset, val.length), val.length, val.length)
     while (offset < end && val[offset] === 0) offset++
     if (end === offset) return 0
-    return parseInt(val.subarray(offset, end).toString(), 8)
+    return parseInt(b4a.toString(val.subarray(offset, end)), 8)
   }
 }
 


### PR DESCRIPTION
Header decoding would sometimes fail in the browser due to mixing of polyfilled `Buffer` and `Uint8Array`. I found two instances of calling `toString()` directly on a `Uint8Array` eventually leading to the checksum failing. This would happen semi-rarely based on the performance of the stream writing to `tar-stream`.

I have replaced the `toString()` calls with usage of `b4a`.