### PR TITLE
Fix typo in BufferList.shiftFirst.

### DIFF
--- a/extract.js
+++ b/extract.js
@@ -20,7 +20,7 @@ class BufferList {
   }
 
   shiftFirst (size) {
-    return this._buffered === 0 ? null : this._next(size)
+    return this.buffered === 0 ? null : this._next(size)
   }
 
   shift (size) {


### PR DESCRIPTION
I believe this is a typo (or was renamed at some point). I'm not entirely sure how to reproduce this to add a test, but all existing tests still pass.