### PR TITLE
chore: make `bare-fs` an optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,13 +28,21 @@
     "url": "https://github.com/mafintosh/tar-stream/issues"
   },
   "homepage": "https://github.com/mafintosh/tar-stream",
+  "peerDependencies": {
+    "bare-fs": "*"
+  },
+  "peerDependenciesMeta": {
+    "bare-fs": {
+      "optional": true
+    }
+  },
   "dependencies": {
     "b4a": "^1.6.4",
-    "bare-fs": "^4.5.5",
     "fast-fifo": "^1.2.0",
     "streamx": "^2.15.0"
   },
   "devDependencies": {
+    "bare-fs": "^4.5.5",
     "brittle": "^3.3.2",
     "concat-stream": "^2.0.0",
     "standard": "^17.0.1"


### PR DESCRIPTION
The total installation size of `bare-fs` is 3.6MB, and most node users do not need this package.

[<img width="1536" height="168" alt="image" src="https://github.com/user-attachments/assets/4c946f22-f253-435a-b7ad-f1ed2bafccf9" />](https://npmx.dev/package/tar-stream/v/3.1.8)
